### PR TITLE
Code caching for the "programmer" screensaver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ pip-log.txt
 .coverage
 .tox
 
+# Source Code Cache
+termsaver_cache.list

--- a/termsaverlib/constants.py
+++ b/termsaverlib/constants.py
@@ -107,3 +107,5 @@ class Settings(PropertyClass):
     Defines the interval between each fetching of data over the Internet.
     Default value is 1 hour.
     """
+
+    TERMSAVER_DEFAULT_CACHE_FILENAME = 'termsaver_cache.list'

--- a/termsaverlib/screen/base/filereader.py
+++ b/termsaverlib/screen/base/filereader.py
@@ -123,8 +123,18 @@ class FileReaderBase(ScreenBase, TypingHelperBase):
         if not os.path.exists(self.path):
             raise exception.PathNotFoundException(self.path)
 
+        lineData = None
+        if constants.Settings.TERMSAVER_DEFAULT_CACHE_FILENAME in os.listdir(os.getcwd()):
+            print 'found cache!'
+            with open(constants.Settings.TERMSAVER_DEFAULT_CACHE_FILENAME) as f:
+                fileData = [line[:-1] for line in f if line != '']
+            file_list = fileData
         # get the list of available files
-        file_list = self._recurse_to_list(self.path)
+        else:
+            file_list = self._recurse_to_list(self.path)
+            fileStr   = '\n'.join(file_list)
+            with open(constants.Settings.TERMSAVER_DEFAULT_CACHE_FILENAME, 'w') as f:
+                f.write(fileStr)
 
         if len(file_list) == 0:
             raise exception.PathNotFoundException(self.path)


### PR DESCRIPTION
This is great if using a massive directory for the "programmer" screensaver - I use the linux kernel, for which filereader.py otherwise takes several minutes for termsaver to enumerate & check each file.
