### PR TITLE
Plugin Support

### DIFF
--- a/termsaver
+++ b/termsaver
@@ -185,8 +185,9 @@ if __name__ == '__main__':
                 error_message = e.message
             else:
                 error_message = e
-            print (_('Oops! Could not find path for %(path)s. %(msg)s')) % \
-                {'path': e.path, 'msg': error_message}
+            
+            print (_('Oops! Could not find path for %(path)s. %(msg)s') % \
+                {'path': e.path, 'msg': error_message})
 
         elif isinstance(e, exception.InvalidOptionException):
             #

--- a/termsaverlib/plugins/__init__.py
+++ b/termsaverlib/plugins/__init__.py
@@ -76,7 +76,7 @@ Additional rules before you begin:
     application to find the screen, and handle input/output accordingly.
 
 
-This sctructure is designed to immitate termsaver's main structure, so once you
+This structure is designed to immitate termsaver's main structure, so once you
 get familiar with it, it should be piece of cake to manage your own "space".
 
 """
@@ -86,6 +86,7 @@ get familiar with it, it should be piece of cake to manage your own "space".
 #
 import os
 import inspect
+import sys
 
 #
 # Internal modules
@@ -106,11 +107,17 @@ def get_available_plugin_screens():
         if (os.path.isdir(os.path.join(os.path.dirname(__file__), plugin))):
             # we are inside the plugin directory, get screens available in
             # screens directory
+
             for module in os.listdir(os.path.join(os.path.dirname(__file__),
                     plugin, "screen")):
+
                 if module in ignore_list or module[-3:] != '.py':
                     continue
+
                 module_name = plugin + ".screen." + module[:-3]
+
+                if os.path.join(os.path.dirname(__file__)) not in sys.path:
+                    sys.path.append(os.path.join(os.path.dirname(__file__)))
 
                 m = __import__(module_name, globals(), locals(),
                         [module_name.rsplit(".", 1)[-1]])

--- a/termsaverlib/plugins/exampleplugin/constants.py
+++ b/termsaverlib/plugins/exampleplugin/constants.py
@@ -49,12 +49,12 @@ class Plugin(PropertyClass):
     Refer to CHANGELOG file for a complete history about this project.
     """
 
-    NAME = 'termsaver-sampleplugin'
+    NAME = 'termsaver-exampleplugin'
     """
     Defines the termsaver-exampleplugin plugin, usually the plugin package name.
     """
 
-    TITLE = 'TermSaver Sample Plugin'
+    TITLE = 'TermSaver Example Plugin'
     """
     Defines the termsaver-exampleplugin plugin's official name as it should appear
     in documentation.
@@ -62,7 +62,7 @@ class Plugin(PropertyClass):
 
     DESCRIPTION = 'A set of screens for showing an example termsaver plugin.'
     """
-    Defines the main description of the termsaver-sampleplugin plugin.
+    Defines the main description of the termsaver-exampleplugin plugin.
     """
 
     URL = 'http://www.termsaver.info/plugins'

--- a/termsaverlib/plugins/exampleplugin/constants.py
+++ b/termsaverlib/plugins/exampleplugin/constants.py
@@ -1,0 +1,98 @@
+###############################################################################
+#
+# file:     constants.py
+#
+# Purpose:  refer to module documentation for details
+#
+# Note:     This file is part of Termsaver-Example plugin, and should not be
+#           used or executed separately.
+#
+###############################################################################
+#
+# Copyright 2012 Termsaver
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+"""
+Holds constant values used throughout termsaver-exampleplugin plugin.
+"""
+
+#
+# Termsaver modules
+#
+from termsaverlib.constants import PropertyClass
+
+
+class Plugin(PropertyClass):
+    """
+    Holds application related properties used by termsaver-exampleplugin plugin
+    screens. Refer to each of the available properties for detailed
+    documentation.
+    """
+
+    VERSION = "0.1"
+    """
+    Defines the version of termsaver-exampleplugin plugin. This is accessed during
+    install process, and to any help and usage messages informed by it.
+
+    Refer to CHANGELOG file for a complete history about this project.
+    """
+
+    NAME = 'termsaver-sampleplugin'
+    """
+    Defines the termsaver-exampleplugin plugin, usually the plugin package name.
+    """
+
+    TITLE = 'TermSaver Sample Plugin'
+    """
+    Defines the termsaver-exampleplugin plugin's official name as it should appear
+    in documentation.
+    """
+
+    DESCRIPTION = 'A set of screens for showing an example termsaver plugin.'
+    """
+    Defines the main description of the termsaver-sampleplugin plugin.
+    """
+
+    URL = 'http://www.termsaver.info/plugins'
+    """
+    Defines the termsaver-exampleplugin plugin official website address.
+    """
+
+    SOURCE_URL = 'http://github.com/brunobraga/termsaver'
+    """
+    Defines the termsaver-exampleplugin plugin official source-code control site,
+    hosted on GitHub.
+    """
+
+    AUTHORS = ['Bruno Braga <bruno.braga@gmail.com>']
+    """
+    Defines a list of all authors contributing to the termsaver-exampleplugin plugin.
+    """
+
+
+class Settings(PropertyClass):
+    """
+    Holds configuration settings used by termsaver-exampleplugin plugin. Refer to each
+    of the available properties for detailed documentation.
+
+    Follow the formatting:
+
+    SETTING_NAME = VALUE
+    \"\"\"
+    document it!
+    \"\"\"
+
+    """
+    pass

--- a/termsaverlib/plugins/exampleplugin/screen/__init__.py
+++ b/termsaverlib/plugins/exampleplugin/screen/__init__.py
@@ -1,0 +1,28 @@
+###############################################################################
+#
+# file:     __init__.py
+#
+# Purpose:  refer to package documentation for details
+#
+# Note:     This file is part of Termsaver-ExamplePlugin plugin, and should not be
+#           used or executed separately.
+#
+###############################################################################
+#
+# Copyright 2012 Termsaver
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+"""
+"""

--- a/termsaverlib/plugins/exampleplugin/screen/base/__init__.py
+++ b/termsaverlib/plugins/exampleplugin/screen/base/__init__.py
@@ -1,0 +1,67 @@
+###############################################################################
+#
+# file:     __init__.py
+#
+# Purpose:  refer to module documentation for details
+#
+# Note:     This file is part of Termsaver-ExamplePlugin plugin, and should not be used
+#           or executed separately.
+#
+###############################################################################
+#
+# Copyright 2012 Termsaver
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+"""
+This module holds base classes that are used by all screens within termsaver
+application. Each individual "screen" represents a unique screensaver that can
+be triggered by termsaver.
+
+The base classes available in this package are:
+
+  * `ExamplePluginScreenBase`: the most basic screen class, which will handle simple
+     interaction with the terminal.
+
+
+"""
+
+#
+# Python built-in modules
+#
+import os
+import textwrap
+
+#
+# Internal modules
+#
+from termsaverlib.screen.base import ScreenBase
+from termsaverlib import common, exception
+from termsaverlib.screen.helper.position import PositionHelperBase
+from termsaverlib.i18n import _, set_app
+
+#
+# Override termsavr default i18n (reuired for plugins with own i18n files)
+#
+set_app("termsaver-exampleplugin")
+
+class ExamplePluginScreenBase(ScreenBase, PositionHelperBase):
+  """
+  """
+
+  def example_echo(self, echo_text):
+    """
+    Just echos the incoming text
+    """
+    return echo_text

--- a/termsaverlib/plugins/exampleplugin/screen/eps.py
+++ b/termsaverlib/plugins/exampleplugin/screen/eps.py
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# file:     SamplePluginScreen.py
+# file:     ExamplePluginScreen.py
 #
 # Purpose:  An attempt at the starwars asciimation
 #

--- a/termsaverlib/plugins/exampleplugin/screen/eps.py
+++ b/termsaverlib/plugins/exampleplugin/screen/eps.py
@@ -1,0 +1,114 @@
+###############################################################################
+#
+# file:     SamplePluginScreen.py
+#
+# Purpose:  An attempt at the starwars asciimation
+#
+# Note:     This file is part of Termsaver application, and should not be used
+#           or executed separately.
+#
+###############################################################################
+#
+# Copyright 2020 Termsaver
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+"""
+This module contains an example plugin screen.
+
+The screen class available here is:
+
+    * `ExamplePluginScreen`
+"""
+
+#
+# Internal modules
+#
+from termsaverlib.screen.base import ScreenBase
+from termsaverlib.screen.helper.position import PositionHelperBase
+from termsaverlib import common
+from termsaverlib.i18n import _, set_app
+
+import itertools
+
+import time
+import io
+
+from termsaverlib.plugins.exampleplugin.screen.base import ExamplePluginScreenBase
+
+set_app("termsaver-exampleplugin")
+
+class ExamplePluginScreen(ExamplePluginScreenBase):
+    """
+    An Example Plugin Screen
+    """
+
+    def __init__(self):
+        """
+        The constructor of this class.
+        """
+        ScreenBase.__init__(self,
+            "exampleplugin",
+            _("the example plugin"),
+            {'opts': 'h', 'long_opts': ['help']})
+        self.cleanup_per_cycle = True
+
+    def _run_cycle(self):
+        """
+        Executes a cycle of this screen.
+        """
+        
+        print(self.example_echo("Hello World"))
+        time.sleep(1)
+
+    def _usage_options_example(self):
+            """
+            Describe here the options and examples of this screen.
+
+            The method `_parse_args` will be handling the parsing of the options
+            documented here.
+
+            Additionally, this is dependent on the values exposed in `cli_opts`,
+            passed to this class during its instantiation. Only values properly
+            configured there will be accepted here.
+            """
+            print (_("""
+
+            This is the example plugin. There are no options!
+
+            Options:
+            -h, --help   Displays this help message
+        
+    """))
+
+    def _parse_args(self, prepared_args):
+        """
+        Handles the special command-line arguments available for this screen.
+        Although this is a base screen, having these options prepared here
+        can save coding for screens that will not change the default options.
+
+        See `_usage_options_example` method for documentation on each of the
+        options being parsed here.
+
+        Additionally, this is dependent on the values exposed in `cli_opts`,
+        passed to this class during its instantiation. Only values properly
+        configured there will be accepted here.
+        """
+        for o, a in prepared_args[0]:  # optlist, args
+            if o in ("-h", "--help"):
+                self.usage()
+                self.screen_exit()
+            else:
+                # this should never happen!
+                raise Exception(_("Unhandled option. See --help for details."))


### PR DESCRIPTION
This is the primary draft PR for Issue #36, etc.

So far I have fixed the loading of plugins and started work on an example plugin to demonstrate functionality. I have also looked at https://github.com/brunobraga/termsaver-figlet which also needs updating to python3.8+.  

Fun fact: The figlet plugin above sort of works out of the box but we should note somewhere that plugin folders shouldn't be named the same as an existing/installed module. I.E. On plugin load "termsaverlib.plugins.figlet.screen.base" will fail because "figlet.screen" does not exist. (Want to guess how long it took me to figure that out at midnight on a weekday? :|  )