### PR TITLE
Added automagic support for pygments to the Programming Screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ website, from its hourly updated [RSS](http://en.wikipedia.org/wiki/RSS) feed.
 #### Programmer
 
 This is a screensaver that displays source code from a specified path in
-visual animation.
-
+visual animation. If the [pygments](https://pygments.org/) package is installed, this screensaver
+will use it to color the displayed files based on their type.
 
 #### Quotes For All
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ website, from its hourly updated [RSS](http://en.wikipedia.org/wiki/RSS) feed.
 
 This is a screensaver that displays source code from a specified path in
 visual animation. If the [pygments](https://pygments.org/) package is installed, this screensaver
-will use it to color the displayed files based on their type.
+will apply syntax highlighting based on the file type.
 
 #### Quotes For All
 

--- a/doc/termsaver.1
+++ b/doc/termsaver.1
@@ -58,7 +58,7 @@ displays word in random places on screen
 randomly displays RFC contents
 .TP 
 .B programmer     
-displays source code in typing animation
+displays source code in typing animation (optional pygments support)
 .TP 
 .B urlfetcher     
 displays url contents with typing animation

--- a/extras/README.dist
+++ b/extras/README.dist
@@ -154,7 +154,8 @@ Programmer
 ----------
 
 This is a screensaver that displays source code from a specified path in
-visual animation.
+visual animation. If pygments is installed then it will also color code
+the files based on their type.
 
 Quotes For All
 --------------

--- a/extras/README.dist
+++ b/extras/README.dist
@@ -154,8 +154,8 @@ Programmer
 ----------
 
 This is a screensaver that displays source code from a specified path in
-visual animation. If pygments is installed then it will also color code
-the files based on their type.
+visual animation. If pygments is installed then it will apply syntax
+highlighting based on the file type.
 
 Quotes For All
 --------------

--- a/termsaverlib/screen/base/filereader.py
+++ b/termsaverlib/screen/base/filereader.py
@@ -48,7 +48,7 @@ from termsaverlib.screen.base import ScreenBase
 from termsaverlib import exception, constants
 from termsaverlib.screen.helper.typing import TypingHelperBase
 from termsaverlib.i18n import _
-
+import importlib
 
 class FileReaderBase(ScreenBase, TypingHelperBase):
     """
@@ -101,9 +101,23 @@ class FileReaderBase(ScreenBase, TypingHelperBase):
             }
         self.delay = delay
         self.path = path
+        self.ignore_binary = False
         self.cleanup_per_cycle = False
+        self.colorize = False
+        self.pygments_installed = False
+        self.is_initalized = False
 
     def _run_cycle(self):
+        if self.is_initalized is False:
+            #if 'pygments' in sys.modules:
+            pygments_spec = importlib.util.find_spec('pygments')
+            found = pygments_spec is not None
+            if found is True:
+                from pygments import highlight
+                from pygments.lexers import guess_lexer
+                from pygments.formatters import TerminalFormatter
+                self.pygments_installed = True
+            self.is_initalized = True
         """
         Executes a \"cycle\" of this screen.
             * The concept of \"cycle\" is no longer accurate, and is misleading.
@@ -146,12 +160,24 @@ class FileReaderBase(ScreenBase, TypingHelperBase):
         threads = [FileReaderBase.FileScannerThread(self, queue_of_valid_files, self.path)]
         threads[-1].daemon = True
         threads[-1].start()
+        
+        print(_("""
+Scanning path for supported files.
+If this message does not disappear then there are no supported file types in the given path."""))
+
+        nextFile = queue_of_valid_files.get()
+    
         #self.clear_screen() hides any error message produced before it!
         self.clear_screen()
-        nextFile = queue_of_valid_files.get()
+
         while nextFile:
             with open(nextFile, 'r') as f:
                 file_data = f.read()
+                if self.pygments_installed is True:
+                    if self.colorize is True:
+                        lexer = guess_lexer(file_data)
+                        formatter = TerminalFormatter
+                        file_data = highlight(file_data,lexer,formatter())
                 self.typing_print(file_data)
             if self.cleanup_per_file:
                 self.clear_screen()
@@ -250,8 +276,11 @@ Examples:
                     if os.path.isdir(f):
                         if not item.startswith('.'):
                             self._recurse_to_exec(f, func, filetype)
-                    elif f.endswith(filetype) and not self._is_path_binary(f):
-                        func(f)
+                    elif f.endswith(filetype):
+                        if self.ignore_binary is False and not self._is_path_binary(f):
+                            func(f)
+                        elif self.ignore_binary is True and self._is_path_binary(f):
+                            func(f)
             elif path.endswith(filetype) and not self._is_path_binary(path):
                 func(path)
         except:

--- a/termsaverlib/screen/programmer.py
+++ b/termsaverlib/screen/programmer.py
@@ -69,6 +69,8 @@ class ProgrammerScreen(FileReaderBase):
             _("displays source code in typing animation"))
         self.cleanup_per_cycle = True
         self.cleanup_per_file = True
+        self.colorize = True
+        self.ignore_binary = True
 
     def _message_no_path(self):
         """

--- a/termsaverlib/screen/programmer.py
+++ b/termsaverlib/screen/programmer.py
@@ -66,7 +66,7 @@ class ProgrammerScreen(FileReaderBase):
         """
         FileReaderBase.__init__(self,
             "programmer",
-            _("displays source code in typing animation"))
+            _("displays source code in typing animation (with pygments support)"))
         self.cleanup_per_cycle = True
         self.cleanup_per_file = True
         self.colorize = True


### PR DESCRIPTION
New Draft PR for old #22 

This will check if pygments is installed and enable itself automatically. Needs testing on windows and mac but I doubt there will be an issue.

@brunobraga 
Do we want options in the programming screen to force this off/on instead of letting the system detect pygments?

I'm not sure the FileReaderBase method of detecting a binary file is adequate with Python3. Even though the source code I tested (py, pyc, html, css, js) were all text files, it was returning True for binary.  There are other methods we could use, including support for a whitelist of filetypes using the mimetype library (which I have toyed with in another branch), or other safer routes if we're willing to import something like [python-magic](https://github.com/ahupp/python-magic). What are your thoughts?