### PR TITLE
Implemented 'quit on any input' option.

### DIFF
--- a/termsaver.py
+++ b/termsaver.py
@@ -41,23 +41,22 @@ See more details of this documentation in:
     * `parse_args` function
 """
 
+import argparse
+import errno
 #
 # Python built-in modules
 #
 import sys
-import errno
 
+from termsaverlib import common, constants, exception
+from termsaverlib.helper.smartformatter import SmartFormatter
+from termsaverlib.i18n import _
 #
 # Internal modules
 #
 from termsaverlib.screen import build_screen_usage_list, get_available_screens
 from termsaverlib.screen.base import ScreenBase
 from termsaverlib.screen.helper import ScreenHelperBase
-from termsaverlib import common, exception, constants
-from termsaverlib.i18n import _
-
-import argparse
-from termsaverlib.helper.smartformatter import SmartFormatter
 
 verbose = False
 """
@@ -86,6 +85,11 @@ Options:
 
  -h, --help     Displays this help message
  -v, --verbose  Displays python exception errors (for debugging)
+
+Enhanced Features:
+ * Install the following modules to enable enhanced features:
+    * pynput - Enables the 'Press any key to exit' feature.
+    * pygments - Colorizes the output of the Programmer screen.
 
 Refer also to each screen's help by typing: %(app_name)s [screen] -h
 """) % {

--- a/termsaverlib/screen/base/__init__.py
+++ b/termsaverlib/screen/base/__init__.py
@@ -79,25 +79,23 @@ consistent).
 
 """
 
-import getopt
-import importlib
 #
 # Python built-in modules
 #
-import os
+import subprocess
 import sys
 
-pynput_installed = importlib.util.find_spec('pynput')
-if (pynput_installed is not None):
+pynput_installed = None
+reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
+installed_packages = [r.decode().split('==')[0] for r in reqs.split()]
+if 'pynput' in installed_packages:
+    pynput_installed = True
     from pynput import keyboard
 
 #
-import argparse
-
 # Internal modules
 #
-from termsaverlib import common, constants, exception
-from termsaverlib.helper.smartformatter import SmartFormatter
+from termsaverlib import constants
 from termsaverlib.i18n import _
 from termsaverlib.screen.helper import ScreenHelperBase
 


### PR DESCRIPTION
Fixes #51 

To test properly, first try pressing a key with, then without **pynput** installed. There is a delay on quitting after the keypress, due to the internal timer. This is expected and the best we can do for now.