### PR TITLE
Adds variant and ascii  characters to sysmon

### DIFF
--- a/termsaverlib/screen/sysmon.py
+++ b/termsaverlib/screen/sysmon.py
@@ -150,7 +150,7 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
             self.parser.add_argument("-n","--no-adjust", dest="adjust", action="store_true", help="""
             Forces the charts to displays 0 ~ 100%% values, instead of dynamically adjusted values based on current maximum.
             """)
-            self.parser.add_argument("-p","--path", action="store_true", default=False, help="""
+            self.parser.add_argument("-p","--path", help="""
             Sets the location of a file to be monitored. The file must only contain a number from 0 to 100, or the screen will not start.
             This option is optional.
             """)
@@ -158,7 +158,7 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
             Sets the alternative mode, which uses a different set of unicode symbols to draw the charts.
             Will not work with -a / -ascii option.
             """)
-            self.parser.add_argument("-a", "--ascii", help="""
+            self.parser.add_argument("-a", "--ascii", action="store_true", default=False, help="""
             Sets the ASCII mode, which uses only ASCII characters to draw the charts.
             Will not work with -v / -variant option.
             """)

--- a/termsaverlib/screen/sysmon.py
+++ b/termsaverlib/screen/sysmon.py
@@ -150,11 +150,11 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
             self.parser.add_argument("-n","--no-adjust", dest="adjust", action="store_true", help="""
             Forces the charts to displays 0 ~ 100%% values, instead of dynamically adjusted values based on current maximum.
             """)
-            self.parser.add_argument("-p","--path", help="""
+            self.parser.add_argument("-p","--path", action="store_true", default=False, help="""
             Sets the location of a file to be monitored. The file must only contain a number from 0 to 100, or the screen will not start.
             This option is optional.
             """)
-            self.parser.add_argument("-v", "--variant", help="""
+            self.parser.add_argument("-v", "--variant",  action="store_true", default="False", help="""
             Sets the alternative mode, which uses a different set of unicode symbols to draw the charts.
             Will not work with -a / -ascii option.
             """)

--- a/termsaverlib/screen/sysmon.py
+++ b/termsaverlib/screen/sysmon.py
@@ -34,20 +34,20 @@ The screen class available here is:
     * `SysmonScreen`
 """
 
+import os
+import re
 #
 # Python mobdules
 #
 import time
-import re
-import os
 
+from termsaverlib import common, constants, exception
+from termsaverlib.i18n import _
 #
 # Internal modules
 #
 from termsaverlib.screen.base import ScreenBase
 from termsaverlib.screen.helper.position import PositionHelperBase
-from termsaverlib import constants, exception, common
-from termsaverlib.i18n import _
 
 
 class SysmonScreen(ScreenBase, PositionHelperBase):
@@ -95,23 +95,31 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
     # Graphical elements
     #
 
-    pie_chart = ['○', '◔', '◑', '◕', '●']
+    pie_chart = [
+        ['○', '◔', '◑', '◕', '●'],
+        [' ', '|', '(', 'C', 'O'],
+        [' ', '|', '(', 'C', 'O']
+    ]
     """
     Holds the unicode symbols for pie chart representation of percentage
     """
-    block = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█', '█']
+    block = [
+        [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█', '█'],
+        [' ', '\033(0s\033(B', '\033(0s\033(B', '\033(0s\033(B', '\033(0s\033(B', '\033[7m \033[27m', '\033[7m \033[27m', '\033[7m \033[27m', '\033[7m \033[27m', '\033[7m \033[27m'],
+        [' ', '_', '_', 'm', 'm', 'm', '#', '#', '#', '#']
+    ]
     """
     Holds the block unicode symbolds used to draw the charts
     """
-    axis_corner = "└"
+    axis_corner = ["└","\033(0m\033(B","+"]
     """
     Represents the unicode symbol for the axis corner in the xy chart
     """
-    axis_h = "─"
+    axis_h = ["─","\033(0q\033(B","-"]
     """
     Represents the unicode symbol for the horizontal axis in the xy chart
     """
-    axis_v = "│"
+    axis_v = ["│","\033(0x\033(B","|"]
     """
     Represents the unicode symbol for the vertical axis in the xy chart
     """
@@ -146,6 +154,16 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
             Sets the location of a file to be monitored. The file must only contain a number from 0 to 100, or the screen will not start.
             This option is optional.
             """)
+            self.parser.add_argument("-v", "--variant", help="""
+            Sets the alternative mode, which uses a different set of unicode symbols to draw the charts.
+            Will not work with -a / -ascii option.
+            """)
+            self.parser.add_argument("-a", "--ascii", help="""
+            Sets the ASCII mode, which uses only ASCII characters to draw the charts.
+            Will not work with -v / -variant option.
+            """)
+        
+        self.symbol_index = 0
 
         #
         # Due to a time delay to calculate CPU usage
@@ -315,8 +333,8 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
         given.
         """
         pos = int(perc * 5 / 100)
-        if pos < len(self.pie_chart) and pos >= 0:
-            return self.pie_chart[pos]
+        if pos < len(self.pie_chart[self.symbol_index]) and pos >= 0:
+            return self.pie_chart[self.symbol_index][pos]
         else:
             return ""
 
@@ -334,7 +352,7 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
         # create output (11 lines)
         for y in range(ysize - 1, -1, -1):
             current_position = 0
-            txt += " " + self.axis_v
+            txt += " " + self.axis_v[self.symbol_index]
             for x in range(self.geometry['x'] - 5): # padding
                 if len(self.info['db']) - 1 < x:
                     txt += " "
@@ -348,17 +366,17 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
 
                     # based on number of blocks (10)
                     if ratio >= y + 1:
-                        txt += self.block[-1]
+                        txt += self.block[self.symbol_index][-1]
                     elif y > 0 and ratio > y:
-                        txt += self.block[ratio - y]
+                        txt += self.block[self.symbol_index][ratio - y]
                     elif y > 0:
-                        txt += self.block[0]
+                        txt += self.block[self.symbol_index][0]
                     else:
-                        txt += self.block[1]
+                        txt += self.block[self.symbol_index][1]
 
             txt += "\n"
 
-        txt += " " + self.axis_corner + self.axis_h * (self.geometry['x'] - 5) + "\n"
+        txt += " " + self.axis_corner[self.symbol_index] + self.axis_h[self.symbol_index] * (self.geometry['x'] - 5) + "\n"
 
         txt += "%s%s%s\n" % (self.format_time(self.info['db'][0]['time']),
                 " " * (current_position - 5), _("now"))
@@ -421,6 +439,11 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
                 self.delay = float(args.delay)
             except:
                 raise exception.InvalidOptionException("delay")
+
+        if args.variant:
+            self.symbol_index = 1
+        elif args.ascii:
+            self.symbol_index = 2
 
         if launchScreenImmediately:
             self.autorun()

--- a/termsaverlib/screen/sysmon.py
+++ b/termsaverlib/screen/sysmon.py
@@ -130,6 +130,11 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
     value available
     """
 
+    symbol_index = 0
+    """
+    Holds the index of the symbol set we're using.
+    """
+
 
     def __init__(self, parser = None):
         """
@@ -162,9 +167,6 @@ class SysmonScreen(ScreenBase, PositionHelperBase):
             Sets the ASCII mode, which uses only ASCII characters to draw the charts.
             Will not work with -v / -variant option.
             """)
-        
-        self.symbol_index = 0
-
         #
         # Due to a time delay to calculate CPU usage
         # we need to clear the screen manually


### PR DESCRIPTION
Fixes #38 

This feature adds two new parameters to sysmon:

- -v/--variant - Variant Symbols
- -a/--ascii     - ASCII Symbols

Only one of the flags may be used at a time (Variant superseding ASCII).