### PR TITLE
Shows/Hides the terminal cursor on start/exit.

### DIFF
--- a/termsaver.py
+++ b/termsaver.py
@@ -144,6 +144,7 @@ def getScreen():
         verbose = True if args.verbose else False
         if args.screen == None or (args.screen == None and args.h0elp == True):
             usage()
+            show_stdout_cursor()
             sys.exit(0)
 
         # Find the screen we're using and create it's parser as well as check validity with args.
@@ -159,6 +160,7 @@ def getScreen():
         if screen == None:
             print(_("Invalid Screen."))
             usage()
+            show_stdout_cursor()
             sys.exit(0)
 
         # Pass the parser to the selected screen.
@@ -180,6 +182,7 @@ def getScreen():
             common.prettify_exception(e)
 
         # Just finish gracefully
+        show_stdout_cursor()
         sys.exit(0)
 
     except exception.TermSaverException as e:
@@ -269,6 +272,7 @@ def getScreen():
         if e.help_msg not in (None, ''):
             print(e.help_msg)
 
+        show_stdout_cursor()
         sys.exit(error_number)
 
     except Exception as e:
@@ -300,7 +304,7 @@ option --verbose and copy the output when you are filling
 the bug report, that will help track faster the problem.
 Thanks!
 """))
-
+        show_stdout_cursor()
         sys.exit(errno.EPERM)
 if __name__ == '__main__':
     #

--- a/termsaver.py
+++ b/termsaver.py
@@ -41,23 +41,25 @@ See more details of this documentation in:
     * `parse_args` function
 """
 
+import argparse
+import errno
 #
 # Python built-in modules
 #
 import sys
-import errno
+from signal import SIGINT, signal
 
+from termsaverlib import common, constants, exception
+from termsaverlib.helper.smartformatter import SmartFormatter
+from termsaverlib.helper.utilities import (hide_stdout_cursor,
+                                           show_stdout_cursor)
+from termsaverlib.i18n import _
 #
 # Internal modules
 #
 from termsaverlib.screen import build_screen_usage_list, get_available_screens
 from termsaverlib.screen.base import ScreenBase
 from termsaverlib.screen.helper import ScreenHelperBase
-from termsaverlib import common, exception, constants
-from termsaverlib.i18n import _
-
-import argparse
-from termsaverlib.helper.smartformatter import SmartFormatter
 
 verbose = False
 """
@@ -100,6 +102,11 @@ Refer also to each screen's help by typing: %(app_name)s [screen] -h
 def skip(arg = None):
     pass
 
+def handler(signal_received, frame):
+    # Handle any cleanup here
+    print('SIGINT or CTRL-C detected. Exiting gracefully')
+    show_stdout_cursor()
+    sys.exit(0)
             
 def entryPoint():
     tscreen = getScreen()
@@ -300,4 +307,6 @@ if __name__ == '__main__':
     # The entry point of this application, as this should not be accessible as
     # a python module to be imported by another application.
     #
+    signal(SIGINT, handler)
+    hide_stdout_cursor()
     entryPoint()

--- a/termsaverlib/helper/utilities.py
+++ b/termsaverlib/helper/utilities.py
@@ -1,0 +1,46 @@
+###############################################################################
+#
+# file:     utilities.py
+#
+# Purpose:  refer to module documentation for details
+#
+# Note:     This file is part of Termsaver application, and should not be used
+#           or executed separately.
+#
+###############################################################################
+#
+# Copyright 2012 Termsaver
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+import sys
+
+
+def hide_stdout_cursor():
+    sys.stdout.write("\033[?25l")
+
+def show_stdout_cursor():
+    sys.stdout.write('\033[?25h')
+
+def hide_cursor():
+    """
+    Hides the cursor.
+    """
+    print("\033[?25l", end="")
+
+def show_cursor():
+    """
+    Shows the cursor.
+    """
+    print('\033[?25h', end="")

--- a/termsaverlib/screen/base/__init__.py
+++ b/termsaverlib/screen/base/__init__.py
@@ -85,6 +85,8 @@ consistent).
 import subprocess
 import sys
 
+from termsaverlib.helper.utilities import show_stdout_cursor
+
 pynput_installed = None
 reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 installed_packages = [r.decode().split('==')[0] for r in reqs.split()]
@@ -245,6 +247,7 @@ class ScreenBase(ScreenHelperBase):
             # Clear screen if appropriate
             if self.cleanup_per_cycle:
                 self.clear_screen()
+        show_stdout_cursor()
 
     def _run_cycle(self):
         """


### PR DESCRIPTION
This PR hides/shows the terminal cursor on start and on CTRL+C/SIGINT.  This functionality will need to be added to #56 after the codebase is stabilized.

Implements #35 